### PR TITLE
The `hook_del` function is missing the `hook` parameter

### DIFF
--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -258,7 +258,7 @@ var uc = {
             return hook
         }
 
-        this.hook_del = function () {
+        this.hook_del = function (hook) {
             var handle = MUnicorn.getValue(this.handle_ptr, '*');
             var ret = MUnicorn.ccall('uc_hook_del', 'number',
                 ['pointer', 'pointer'],


### PR DESCRIPTION
The `hook_del` function was missing the `hook` parameter, so there was no way to delete hooks. Calling the function would result in an error saying the `hook` variable was undefined.