### PR TITLE
Resolve 64 bit register and memory read write issue

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,6 +24,7 @@ module.exports = function (grunt) {
             dist: {
                 src: [
                     'src/libunicorn<%= lib.suffix %>.out.js',
+                    'src/libelf-integers.js',
                     'src/unicorn-wrapper.js',
                     'src/unicorn-constants.js',
                 ],

--- a/src/libelf-integers.js
+++ b/src/libelf-integers.js
@@ -40,9 +40,9 @@ var ElfUInt = function (width) {
                     this.chunks[i] = value & (i === this.chunks.length - 1 ? this.mask : 0xFFFF);
                     if (value < 0) {
                         // Fix round off of bits in negative values
-                        value -= 65535
+                        value -= 0xFFFF;
                     }
-                    value /= 65536;
+                    value /= 0x10000;
                 }
             }
             // Initialize from String
@@ -51,7 +51,7 @@ var ElfUInt = function (width) {
                     value = value.slice(2);
                 for (var i = 0; i < this.chunks.length; i++) {
                     // Force NaN value to be 0
-                    this.chunks[i] = parseInt(value.slice(-4), 16) || 0;
+                    this.chunks[i] = parseInt(value.slice(-4), 16) | 0;
                     value.slice(0, -4);
                 }
             }

--- a/src/libelf-integers.js
+++ b/src/libelf-integers.js
@@ -1,0 +1,139 @@
+/**
+ * (c) 2018 Libelf.JS
+ * Arbitrary integer emulation
+ * Based on https://github.com/pierrec/js-cuint
+ */
+
+var ElfUInt = function (width) {
+    // Configure properties based on bit-width
+    var mask = (1 << (((width - 1) % 16) + 1)) - 1;
+    var nchunks = (width + 15) / 16;
+
+    // Return class
+    return function (value) {
+        this.width = width;
+        this.chunks = new Uint16Array(nchunks);
+        this.mask = mask;
+
+        // Initialization:
+        // Several checks are omitted since JavaScript will cast any undefined/NaN's
+        // into the appropriate type while writing to the chunks array.
+        if (value == null) {
+            this.chunks.fill(0);
+        } else {
+            // Initialize from Number
+            if (typeof value === 'number') {
+                for (var i = 0; i < this.chunks.length; i++) {
+                    this.chunks[i] = value & 0xFFFF;
+                    value >>>= 16;
+                }
+            }
+            // Initialize from String
+            if (typeof value === 'string') {
+                if (value.toLowerCase().startsWith("0x"))
+                    value = value.slice(2);
+                for (var i = 0; i < this.chunks.length; i++) {
+                    this.chunks[i] = parseInt(value.slice(-4), 16);
+                    value.slice(0, -4);
+                }
+            }
+            // Initialize from Array (32-bit entries)
+            if (typeof value === 'object' && Array.isArray(value)) {
+                for (var i = 0; i < this.chunks.length; i++) {
+                    if (i % 2 == 0)
+                        this.chunks[i] = (value[(i/2)|0] >>>  0) & 0xFFFF;
+                    else
+                        this.chunks[i] = (value[(i/2)|0] >>> 16) & 0xFFFF;
+                }
+            }
+            // Initialize from ElfUInt
+            if (typeof value === 'object' && !Array.isArray(value)) {
+                for (var i = 0; i < this.chunks.length; i++) {
+                    this.chunks[i] = value.chunks[i];
+                }
+            }
+        }
+
+        // Methods
+        this.clone = function () {
+        };
+
+        this.neg = function () {
+            return this.not().add(1);
+        };
+        this.not = function () {
+            var value = new this.constructor(this);
+            for (var i = 0; i < this.chunks.length; i++)
+                value.chunks[i] = ~this.chunks[i];
+            return value;
+        };
+        this.add = function (rhs) {
+            var lhs = new this.constructor(this);
+            var rhs = new this.constructor(rhs);
+            var carry = 0;
+            for (var i = 0; i < this.chunks.length; i++) {
+                var chunk_lhs = lhs.chunks[i];
+                var chunk_rhs = rhs.chunks[i];
+                lhs.chunks[i] = chunk_lhs + chunk_rhs + carry;
+                carry = ((chunk_lhs + chunk_rhs + carry) > 0xFFFF) ? 1 : 0;
+            }
+            return lhs;
+        };
+        this.sub = function (rhs) {
+            var lhs = new this.constructor(this);
+            var rhs = new this.constructor(rhs);
+            return this.add(rhs.neg());
+        };
+        this.mul = function (rhs) {
+            var lhs = new this.constructor(this);
+            var rhs = new this.constructor(rhs);
+            return lhs;
+        };
+        this.div = function (rhs) {
+            var lhs = new this.constructor(this);
+            var rhs = new this.constructor(rhs);
+            return lhs;
+        };
+        this.shl = function (amount) {
+            var value = new this.constructor(this);
+            return value;
+        };
+        this.shr = function (amount) {
+            var value = new this.constructor(this);
+            return value;
+        };
+        this.ror = function (amount) {
+            var value = new this.constructor(this);
+            return value;
+        };
+        this.rol = function (amount) {
+            var value = new this.constructor(this);
+            return value;
+        };
+
+        // Conversion
+        this.hex = function () {
+            var string = "0x";
+            for (var i = this.chunks.length - 1; i >= 0; i--) {
+                var chunkstr = this.chunks[i].toString(16);
+                chunkstr = "0".repeat(4 - chunkstr.length) + chunkstr;
+                string += chunkstr;
+            }
+            return string;
+        }
+        this.num = function () {
+            var number = 0;
+            for (var i = this.chunks.length - 1; i >= 0; i--)
+                number = (number * 0x10000) + this.chunks[i];
+            return number;
+        }
+
+        // Overrides
+        this.valueOf = this.num;
+    };
+};
+
+var ElfUInt8  = ElfUInt(8);
+var ElfUInt16 = ElfUInt(16);
+var ElfUInt32 = ElfUInt(32);
+var ElfUInt64 = ElfUInt(64);

--- a/src/libelf-integers.js
+++ b/src/libelf-integers.js
@@ -29,7 +29,7 @@ var ElfUInt = function (width) {
                         ' is beyond 53 bits integer precision, use other initialization formats for better precision'
                     );
                 }
-                if (value > Math.pow(2, this.width)-1 || value < -Math.pow(2, this.width)) {
+                if (value > Math.pow(2, this.width)-1 || value < -Math.pow(2, this.width-1)) {
                     console.warn(
                         'Libelf.js: number ' + value +
                         ' overflows ' + this.width + ' bits width, use larger width to keep higher bits'
@@ -143,6 +143,12 @@ var ElfUInt = function (width) {
             var number = 0;
             for (var i = this.chunks.length - 1; i >= 0; i--)
                 number = (number * 0x10000) + this.chunks[i];
+            if (!Number.isSafeInteger(number)) {
+                console.warn(
+                    'Libelf.js: number ' + number +
+                    ' is beyond 53 bits integer precision, use other conversion formats for better precision'
+                );
+            }
             return number;
         }
 

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -6,6 +6,11 @@
 // Emscripten demodularize
 var MUnicorn = new MUnicorn();
 
+// Number conversion modes
+ELF_INT_NUMBER  = 1
+ELF_INT_STRING  = 2
+ELF_INT_OBJECT  = 3
+
 var uc = {
     // Static
     version: function() {

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -324,31 +324,31 @@ var uc = {
         }
 
         // Helpers
-            this.__integer = function (value, width) {
-        if (typeof value === "number") {
-            value = [value];
-        }
-        switch (this.get_integer_type()) {
-        case ELF_INT_NUMBER:
-            return value[0];
-        case ELF_INT_STRING:
-            return value
-                .map(x => x.toString(16).toUpperCase())
-                .map(x => '0'.repeat(width/4 - x.length) + x)
-                .reverse().join('');
-        case ELF_INT_OBJECT:
-            switch (width) {
-            case 8:  return new ElfUInt8(value);
-            case 16: return new ElfUInt16(value);
-            case 32: return new ElfUInt32(value);
-            case 64: return new ElfUInt64(value);
-            default: throw 'Unexpected width';
+        this.__integer = function (value, width) {
+            if (typeof value === "number") {
+                value = [value];
             }
-        default:
-            var error = 'Unimplemented integer type';
-            throw error;
+            switch (this.get_integer_type()) {
+            case ELF_INT_NUMBER:
+                return value[0];
+            case ELF_INT_STRING:
+                return value
+                    .map(x => x.toString(16).toUpperCase())
+                    .map(x => '0'.repeat(width/4 - x.length) + x)
+                    .reverse().join('');
+            case ELF_INT_OBJECT:
+                switch (width) {
+                case 8:  return new ElfUInt8(value);
+                case 16: return new ElfUInt16(value);
+                case 32: return new ElfUInt32(value);
+                case 64: return new ElfUInt64(value);
+                default: throw 'Unexpected width';
+                }
+            default:
+                var error = 'Unimplemented integer type';
+                throw error;
+            }
         }
-    }
         this._sizeof = function (type) {
             switch (type) {
                 case 'i8':     return 1;
@@ -364,7 +364,11 @@ var uc = {
             // Allocate space for the output value
             var value_size = this._sizeof(type);
             var value_ptr = MUnicorn._malloc(value_size);
-            MUnicorn.setValue(value_ptr, value, type);
+            // Convert integer types
+            var value_obj = new (ElfUInt(value_size))(value);
+            for (var i = 0; i < value_size/2; i++) {
+                MUnicorn.setValue(value_ptr + i*2, value_obj.chunks[i], 'i16');
+            }
             // Register write
             var handle = MUnicorn.getValue(this.handle_ptr, '*');
             var ret = MUnicorn.ccall('uc_reg_write', 'number',
@@ -399,6 +403,10 @@ var uc = {
             );
             // Get register value, free memory and handle return code
             var value = MUnicorn.getValue(value_ptr, type);
+            // Convert integer types
+            if (type.includes('i')) {
+                value = this.__integer(value, value_size);
+            }
             MUnicorn._free(value_ptr);
             if (ret != uc.ERR_OK) {
                 var error = 'Unicorn.js: Function uc_reg_read failed with code ' + ret + ':\n' + uc.strerror(ret);
@@ -426,6 +434,10 @@ var uc = {
             );
             // Get result value, free memory and handle return code
             var result = MUnicorn.getValue(result_ptr, result_type);
+            // Convert integer types
+            if (type.includes('i')) {
+                result = this.__integer(result, result_size);
+            }
             MUnicorn._free(result_ptr);
             if (ret != uc.ERR_OK) {
                 var error = 'Unicorn.js: Function uc_query failed with code ' + ret + ':\n' + uc.strerror(ret);
@@ -439,7 +451,19 @@ var uc = {
         this.query_i64     = function (type) { return this.query_type(type, 'i64'); }
         this.query_float   = function (type) { return this.query_type(type, 'float'); }
         this.query_double  = function (type) { return this.query_type(type, 'double'); }
+        
+        // Configuration
+        this.get_integer_type = function () {
+            if (this.integer_type == null) {
+                // Using ELF_INT_NUMBER as default for back compatibility
+                return ELF_INT_NUMBER;
+            }
+            return this.integer_type;
+        }
 
+        this.set_integer_type = function (type) {
+            this.integer_type = type;
+        }
 
         // Constructor
         var ret = MUnicorn.ccall('uc_open', 'number',

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -324,6 +324,31 @@ var uc = {
         }
 
         // Helpers
+            this.__integer = function (value, width) {
+        if (typeof value === "number") {
+            value = [value];
+        }
+        switch (this.get_integer_type()) {
+        case ELF_INT_NUMBER:
+            return value[0];
+        case ELF_INT_STRING:
+            return value
+                .map(x => x.toString(16).toUpperCase())
+                .map(x => '0'.repeat(width/4 - x.length) + x)
+                .reverse().join('');
+        case ELF_INT_OBJECT:
+            switch (width) {
+            case 8:  return new ElfUInt8(value);
+            case 16: return new ElfUInt16(value);
+            case 32: return new ElfUInt32(value);
+            case 64: return new ElfUInt64(value);
+            default: throw 'Unexpected width';
+            }
+        default:
+            var error = 'Unimplemented integer type';
+            throw error;
+        }
+    }
         this._sizeof = function (type) {
             switch (type) {
                 case 'i8':     return 1;

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -365,9 +365,11 @@ var uc = {
             var value_size = this._sizeof(type);
             var value_ptr = MUnicorn._malloc(value_size);
             // Convert integer types
-            var value_obj = new (ElfUInt(value_size))(value);
+            var value_obj = new (ElfUInt(value_size*8))(value);
             for (var i = 0; i < value_size/2; i++) {
                 MUnicorn.setValue(value_ptr + i*2, value_obj.chunks[i], 'i16');
+                console.log(value_ptr + i*2);
+                console.log(value_obj.chunks[i])
             }
             // Register write
             var handle = MUnicorn.getValue(this.handle_ptr, '*');
@@ -405,7 +407,7 @@ var uc = {
             var value = MUnicorn.getValue(value_ptr, type);
             // Convert integer types
             if (type.includes('i')) {
-                value = this.__integer(value, value_size);
+                value = this.__integer(value, value_size*8);
             }
             MUnicorn._free(value_ptr);
             if (ret != uc.ERR_OK) {
@@ -436,7 +438,7 @@ var uc = {
             var result = MUnicorn.getValue(result_ptr, result_type);
             // Convert integer types
             if (type.includes('i')) {
-                result = this.__integer(result, result_size);
+                result = this.__integer(result, result_size*8);
             }
             MUnicorn._free(result_ptr);
             if (ret != uc.ERR_OK) {


### PR DESCRIPTION
Closes #21 

The integer implementation is indeed tricky. Even though JavaScript support integer up to 53 bits, the bitwise operation is only 32 bits. I have to borrow the libelf-integers library to do some of the trick.

Nevertheless, full 64 bit support can be enabled through setting the integer type to ELF_INT_OBJECT while keeping backward compatibility of 32 bit native integer using ELF_INT_NUMBER. 64 bit integer/address needs to be passed as an array of [addr_lo, addr_hi] for now. Later I might enhance libelf-integers to support 53 bit integer/address without the need to split it as two parts using Number.isSafeInteger().

@AlexAltea you can now review it and merge this pull. Thanks.