### PR TITLE
Update build script for instruction hook

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,9 +13,9 @@ module.exports = function (grunt) {
             emscripten: {
                 cmd: function (arch) {
                     if (typeof arch === 'undefined') {
-                        return 'python build.py build'
+                        return 'python3 build.py build'
                     } else {
-                        return 'python build.py build ' + arch;
+                        return 'python3 build.py build ' + arch;
                     }
                 }
             }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -43,6 +43,12 @@ module.exports = function (grunt) {
                 }
             }
         },
+        copy: {
+            main: {
+                src: 'src/libunicorn<%= lib.suffix %>.out.wasm',
+                dest: 'dist/unicorn<%= lib.suffix %>.out.wasm'
+            }
+        },
         watch: {
             livereload: {
                 files: [
@@ -66,12 +72,12 @@ module.exports = function (grunt) {
         if (typeof arch === 'undefined') {
             grunt.config.set('lib.suffix', '');
             grunt.task.run('exec:emscripten');
-            grunt.task.run('concat');
         } else {
             grunt.config.set('lib.suffix', '-'+arch);
             grunt.task.run('exec:emscripten:'+arch);
-            grunt.task.run('concat');
         }
+        grunt.task.run('concat');
+        grunt.task.run('copy');
     });
     grunt.registerTask('release', [
         'build',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function (grunt) {
         copy: {
             main: {
                 src: 'src/libunicorn<%= lib.suffix %>.out.wasm',
-                dest: 'dist/unicorn<%= lib.suffix %>.out.wasm'
+                dest: 'dist/libunicorn<%= lib.suffix %>.out.wasm'
             }
         },
         watch: {

--- a/build.py
+++ b/build.py
@@ -395,7 +395,7 @@ def patchUnicornJS():
         "$(MAKE) -C qemu $(SMP_MFLAGS)":
         "$(MAKE) -C qemu $(SMP_MFLAGS)\r\n\t@python " + name,
         '	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}':
-        '	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS} --cpu=i386',
+        '	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS} --disable-stack-protector --cpu=i386',
     })
     # Replace sigsetjmp/siglongjump with setjmp/longjmp
     replace(os.path.join(UNICORN_QEMU_DIR, "cpu-exec.c"), {

--- a/build.py
+++ b/build.py
@@ -566,7 +566,7 @@ def compileUnicorn(targets):
         cmd = ''
         if targets:
             cmd += 'UNICORN_ARCHS="%s" ' % (' '.join(targets))
-        cmd += 'emmake make'
+        cmd += 'emmake make unicorn'
         os.system(cmd)
     os.chdir('..')
 
@@ -590,10 +590,10 @@ def compileUnicorn(targets):
 
 
 def exit_usage():
-    print "Usage: %s <action> [<targets>...]\n" % (sys.argv[0])
-    print "List of actions:"
-    print " - patch: Patch Unicorn only"
-    print " - build: Patch Unicorn and build Unicorn.js"
+    print("Usage: %s <action> [<targets>...]\n" % (sys.argv[0]))
+    print("List of actions:")
+    print(" - patch: Patch Unicorn only")
+    print(" - build: Patch Unicorn and build Unicorn.js")
     exit(1)
 
 if __name__ == "__main__":
@@ -615,7 +615,7 @@ if __name__ == "__main__":
             generateConstants()
             compileUnicorn(targets)
         else:
-            print "Your operating system is not supported by this script:"
-            print "Please, use Emscripten to compile Unicorn manually to src/libunicorn.out.js"
+            print("Your operating system is not supported by this script:")
+            print("Please, use Emscripten to compile Unicorn manually to src/libunicorn.out.js")
     else:
         exit_usage()

--- a/build.py
+++ b/build.py
@@ -394,6 +394,8 @@ def patchUnicornJS():
     replace(os.path.join(UNICORN_DIR, "Makefile"), {
         "$(MAKE) -C qemu $(SMP_MFLAGS)":
         "$(MAKE) -C qemu $(SMP_MFLAGS)\r\n\t@python " + name,
+        '	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS}':
+        '	./configure --cc="${CC}" --extra-cflags="$(UNICORN_CFLAGS)" --target-list="$(UNICORN_TARGETS)" ${UNICORN_QEMU_FLAGS} --cpu=i386',
     })
     # Replace sigsetjmp/siglongjump with setjmp/longjmp
     replace(os.path.join(UNICORN_QEMU_DIR, "cpu-exec.c"), {

--- a/build.py
+++ b/build.py
@@ -571,7 +571,7 @@ def compileUnicorn(targets):
     os.chdir('..')
 
     # Compile static library to JavaScript
-    methods = ['ccall', 'getValue', 'setValue', 'addFunction', 'removeFunction', 'writeArrayToMemory']
+    methods = ['_malloc', 'ccall', 'getValue', 'setValue', 'addFunction', 'removeFunction', 'writeArrayToMemory']
     cmd = 'emcc'
     cmd += ' -Os --memory-init-file 0'
     cmd += ' unicorn/libunicorn.a'
@@ -580,7 +580,7 @@ def compileUnicorn(targets):
     cmd += ' -s RESERVED_FUNCTION_POINTERS=256'
     cmd += ' -s ALLOW_MEMORY_GROWTH=1'
     cmd += ' -s MODULARIZE=1'
-    cmd += ' -s WASM=0'
+    cmd += ' -s WASM=1'
     cmd += ' -s EXPORT_NAME="\'MUnicorn\'"'
     if targets:
         cmd += ' -o src/libunicorn-%s.out.js' % ('-'.join(targets))

--- a/build.py
+++ b/build.py
@@ -548,6 +548,25 @@ def patchUnicornJS():
         "*(int32_t *)(t1 + t2)":
         "(int32_t)UNALIGNED_READ32_LE(t1 + t2)",
     })
+    # Fix unsupported varargs in uc_hook_add function signature
+    replace(os.path.join(UNICORN_DIR, "include/unicorn/unicorn.h"), {
+        "        void *user_data, uint64_t begin, uint64_t end, ...);":
+        "        void *user_data, uint64_t begin, uint64_t end, uint32_t extra);",
+    })
+    replace(os.path.join(UNICORN_DIR, "uc.c"), {
+        "        uc_err err = uc_hook_add(uc, &uc->count_hook, UC_HOOK_CODE, hook_count_cb, NULL, 1, 0);":
+        "        uc_err err = uc_hook_add(uc, &uc->count_hook, UC_HOOK_CODE, hook_count_cb, NULL, 1, 0, 0);",
+        "        void *user_data, uint64_t begin, uint64_t end, ...)":
+        "        void *user_data, uint64_t begin, uint64_t end, uint32_t extra)",
+        "        va_list valist;":
+        "        //va_list valist;",
+        "        va_start(valist, end);":
+        "        //va_start(valist, end);",
+        "        hook->insn = va_arg(valist, int);":
+        "        hook->insn = extra;",
+        "        va_end(valist);":
+        "        //va_end(valist);",
+    })
 
 
 ############

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-connect": "^0.9.0",
+    "grunt-contrib-copy": "^1.0.0",
     "grunt-contrib-watch": "^0.6.1",
     "grunt-exec": "~0.4.6",
     "load-grunt-tasks": "^1.0.0",

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -260,9 +260,8 @@ var uc = {
                 throw 'Unicorn.js: Unimplemented hook type'
             }
             // Set hook
-            var callback_ptr = MUnicorn.Runtime.addFunction(callback);
+            var callback_ptr = MUnicorn.addFunction(callback);
             var hook_ptr = MUnicorn._malloc(4);
-            console.log([extra_types, extra_values])
             var ret = MUnicorn.ccall('uc_hook_add', 'number',
                 ['pointer', 'pointer', 'number', 'pointer', 'pointer',
                     'number', 'number', 'number', 'number', 'number'],
@@ -270,7 +269,7 @@ var uc = {
                     begin, 0, end, 0, extra]
             );
             if (ret != uc.ERR_OK) {
-                MUnicorn.Runtime.removeFunction(callback_ptr);
+                MUnicorn.removeFunction(callback_ptr);
                 MUnicorn._free(hook_ptr);
                 var error = 'Unicorn.js: Function uc_mem_unmap failed with code ' + ret + ':\n' + uc.strerror(ret);
                 throw error;
@@ -293,7 +292,7 @@ var uc = {
                 var error = 'Unicorn.js: Function uc_mem_unmap failed with code ' + ret + ':\n' + uc.strerror(ret);
                 throw error;
             }
-            MUnicorn.Runtime.removeFunction(hook.callback);
+            MUnicorn.removeFunction(hook.callback);
         }
 
         this.emu_start = function (begin, until, timeout, count) {

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -4,7 +4,7 @@
  */
 
 // Emscripten demodularize
-var MUnicorn = new MUnicorn();
+MUnicorn().then(function(instance){MUnicorn = instance});
 
 // Number conversion modes
 ELF_INT_NUMBER  = 1

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -189,7 +189,7 @@ var uc = {
             }
         }
 
-        this.hook_add = function (type, user_callback, user_data, begin, end) {
+        this.hook_add = function (type, user_callback, user_data, begin, end, extra) {
             var handle = MUnicorn.getValue(this.handle_ptr, '*');
             // Default arguments
             if (typeof user_data === 'undefined') {
@@ -201,8 +201,12 @@ var uc = {
                 end = 0;
             }
             // Wrap callback
+            var extra_types = ['number'];
+            var extra_values = [extra];
             switch (type) {
                 case uc.HOOK_INSN:
+                    extra_types = ['number'];
+                    extra_values = [extra];
                     var callback = (function (handle, user_data) {
                         return function (_, _) {
                             user_callback(handle, user_data);
@@ -258,11 +262,12 @@ var uc = {
             // Set hook
             var callback_ptr = MUnicorn.Runtime.addFunction(callback);
             var hook_ptr = MUnicorn._malloc(4);
+            console.log([extra_types, extra_values])
             var ret = MUnicorn.ccall('uc_hook_add', 'number',
                 ['pointer', 'pointer', 'number', 'pointer', 'pointer',
-                    'number', 'number', 'number', 'number'],
+                    'number', 'number', 'number', 'number', 'number'],
                 [handle, hook_ptr, type, callback_ptr, 0,
-                    begin, 0, end, 0]
+                    begin, 0, end, 0, extra]
             );
             if (ret != uc.ERR_OK) {
                 MUnicorn.Runtime.removeFunction(callback_ptr);

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -212,6 +212,7 @@ var uc = {
                             user_callback(handle, user_data);
                         }
                     })(this, user_data);
+                    var callback_ptr = MUnicorn.addFunction(callback, 'vii');
                     break;
                 // uc_cb_hookintr_t
                 case uc.HOOK_INTR:
@@ -220,6 +221,7 @@ var uc = {
                             user_callback(handle, intno, user_data);
                         }
                     })(this, user_data);
+                    var callback_ptr = MUnicorn.addFunction(callback, 'viii');
                     break;
                 // uc_cb_hookcode_t
                 case uc.HOOK_CODE:
@@ -229,6 +231,7 @@ var uc = {
                             user_callback(handle, addr_lo, addr_hi, size, user_data);
                         }
                     })(this, user_data);
+                    var callback_ptr = MUnicorn.addFunction(callback, 'viiii');
                     break;
                 default:
                     // uc_cb_hookmem_t
@@ -241,6 +244,7 @@ var uc = {
                                 user_callback(handle, type, addr_lo, addr_hi, size, value_lo, value_hi, user_data);
                             }
                         })(this, user_data);
+                        var callback_ptr = MUnicorn.addFunction(callback, 'viiiiiiii');
                     }
                     // uc_cb_eventmem_t
                     if ((type & uc.HOOK_MEM_READ_UNMAPPED) ||
@@ -254,13 +258,13 @@ var uc = {
                                 return user_callback(handle, type, addr_lo, addr_hi, size, value_lo, value_hi, user_data);
                             }
                         })(this, user_data);
+                        var callback_ptr = MUnicorn.addFunction(callback, 'iiiiiiiii');
                     }
             }
             if (typeof callback === 'undefined') {
                 throw 'Unicorn.js: Unimplemented hook type'
             }
             // Set hook
-            var callback_ptr = MUnicorn.addFunction(callback);
             var hook_ptr = MUnicorn._malloc(4);
             var ret = MUnicorn.ccall('uc_hook_add', 'number',
                 ['pointer', 'pointer', 'number', 'pointer', 'pointer',


### PR DESCRIPTION
Hi,

As discussed in #20, I have chosen to patch C function because Emscripten does not have support for exported functions with varargs even for newer versions.

The main changes are:

- unicorn-wrapper.js:
    - Update unicorn wrapper for hooking support

- build.py
    - Patch unicorn.h and uc.c functions
    - Build libunicorn.a only, exclude examples in the Makefile when calling make
        - Building examples will fail the Makefile due to signature change and all we need is libunicorn.a
    - Deprecating Python2 as it is end of life
    - Enable webassembly build as asm.js is phased out

- Gruntfile.js and package.json
    - Update pipeline

The build script is verified on emsdk 1.38.48 as we gradually bumping up Emscripten version