### PR TITLE
Bugfixes for Unicorn & Emscripten updates

### DIFF
--- a/build.py
+++ b/build.py
@@ -36,6 +36,8 @@ EXPORTED_FUNCTIONS = [
     '_uc_free',
     '_uc_context_save',
     '_uc_context_restore',
+    '_malloc',
+    '_free',
 ]
 
 EXPORTED_CONSTANTS = [
@@ -593,13 +595,14 @@ def compileUnicorn(targets):
     os.chdir('..')
 
     # Compile static library to JavaScript
-    methods = ['_malloc', 'ccall', 'getValue', 'setValue', 'addFunction', 'removeFunction', 'writeArrayToMemory']
+    methods = ['ccall', 'getValue', 'setValue', 'addFunction', 'removeFunction', 'writeArrayToMemory']
     cmd = 'emcc'
     cmd += ' -Os --memory-init-file 0'
     cmd += ' unicorn/libunicorn.a'
     cmd += ' -s EXPORTED_FUNCTIONS=\"[\''+ '\', \''.join(EXPORTED_FUNCTIONS) +'\']\"'
     cmd += ' -s EXPORTED_RUNTIME_METHODS=\"[\''+ '\', \''.join(methods) +'\']\"'
     cmd += ' -s RESERVED_FUNCTION_POINTERS=256'
+    cmd += ' -s ALLOW_TABLE_GROWTH=1'
     cmd += ' -s ALLOW_MEMORY_GROWTH=1'
     cmd += ' -s MODULARIZE=1'
     cmd += ' -s WASM_ASYNC_COMPILATION=0'

--- a/build.py
+++ b/build.py
@@ -483,8 +483,8 @@ def patchUnicornJS():
         """,
     })
     replace(os.path.join(UNICORN_QEMU_DIR, "include/exec/helper-tcg.h"), {
-        "func = HELPER(NAME)":
-        "func = glue(adapter_helper_, NAME)"
+        "HELPER(NAME)":
+        "glue(adapter_helper_, NAME)"
     })
     # Add arch-suffixes to adapters
     header_gen_patched = False
@@ -515,8 +515,9 @@ def patchUnicornJS():
          for (i = 0; i < nargs; i++) {
              int is_64bit = sizemask & (1 << (i+1)*2);
              if (!is_64bit) {
-                 TCGArg ext_arg = tcg_temp_new_i64(s);
-                 tcg_gen_ext32u_i64(s, ext_arg, args[i]);
+                 TCGv_i64 ext_arg = tcg_temp_new_i64(s);
+                 TCGv_i64 orig = MAKE_TCGV_I64(args[i]);
+                 tcg_gen_ext32u_i64(s, ext_arg, orig);
                  args[i] = GET_TCGV_I64(ext_arg);
              }
          }

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -300,10 +300,14 @@ var uc = {
         }
 
         this.emu_start = function (begin, until, timeout, count) {
+            var [begin_lo, begin_hi] = this.__address(begin);
+            var [until_lo, until_hi] = this.__address(until);
+
             var handle = MUnicorn.getValue(this.handle_ptr, '*');
             var ret = MUnicorn.ccall('uc_emu_start', 'number',
                 ['pointer', 'number', 'number', 'number', 'number', 'number', 'number', 'number'],
-                [handle, begin, 0, until, 0, timeout, 0, count]
+                [handle, begin_lo, begin_hi, until_lo, until_hi,
+                 timeout, 0, count]
             );
             if (ret != uc.ERR_OK) {
                 var error = 'Unicorn.js: Function uc_emu_start failed with code ' + ret + ':\n' + uc.strerror(ret);

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -315,7 +315,7 @@ var uc = {
             }
         }
 
-        this.emu_stop = function (begin, until, timeout, count) {
+        this.emu_stop = function () {
             var handle = MUnicorn.getValue(this.handle_ptr, '*');
             var ret = MUnicorn.ccall('uc_emu_stop', 'number', ['pointer'], [handle]);
             if (ret != uc.ERR_OK) {

--- a/src/unicorn-wrapper.js
+++ b/src/unicorn-wrapper.js
@@ -429,7 +429,12 @@ var uc = {
             // Allocate space for the output value
             var value_size = this._sizeof(type);
             var value_ptr = MUnicorn._malloc(value_size);
-            MUnicorn.setValue(value_ptr, 0, type);
+            if (type === 'i64') {
+                MUnicorn.setValue(value_ptr, 0, 'i32');
+                MUnicorn.setValue(value_ptr + 4, 0, 'i32');
+            } else {
+                MUnicorn.setValue(value_ptr, 0, type);
+            }
 
             // Register read
             var handle = MUnicorn.getValue(this.handle_ptr, '*');
@@ -438,9 +443,14 @@ var uc = {
                 [handle, regid, value_ptr]
             );
             // Get register value, free memory and handle return code
-            var value = MUnicorn.getValue(value_ptr, type);
+            var value;
             if (type === 'i64') {
-                    value = [value, MUnicorn.getValue(value_ptr+4, 'i32')]
+                value = [
+                    MUnicorn.getValue(value_ptr, 'i32'),
+                    MUnicorn.getValue(value_ptr + 4, 'i32')
+                ];
+            } else {
+                value = MUnicorn.getValue(value_ptr, type);
             }
             // Convert integer types
             if (type.includes('i')) {


### PR DESCRIPTION
I tried to build unicorn.js with newer Emscripten and ran into both issues from that and regressions from the Unicorn 1.0.3 version bump, as well as general problems with 64-bit addresses that remained (which were evident with >32bit code addresses on ARM64). This PR fixes those and also improves the ElfUInt abstraction a bit to make it more convenient.

(Note: I used this for the last slide of https://asahilina.net/agx-exploit/)